### PR TITLE
Integrate JPA and security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    runtimeOnly 'org.postgresql:postgresql'
+    testRuntimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Destino.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Destino.java
@@ -1,6 +1,12 @@
 package br.com.senai.agenciaviagem.agenciaviagemapi.model;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "destino")
 public class Destino {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String nome;
     private String local;
@@ -8,32 +14,47 @@ public class Destino {
     private double avaliacaoMedia;
     private int quantidadeAvaliacoes;
 
-    public Destino() {
+    public Destino() {}
+
+    public Long getId() {
+        return id;
     }
 
-    public Destino(Long id, String nome, String local, String descricao) {
+    public void setId(Long id) {
         this.id = id;
-        this.nome = nome;
-        this.local = local;
-        this.descricao = descricao;
-        this.avaliacaoMedia = 0.0;
-        this.quantidadeAvaliacoes = 0;
     }
 
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    public String getNome() {
+        return nome;
+    }
 
-    public String getNome() { return nome; }
-    public void setNome(String nome) { this.nome = nome; }
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
 
-    public String getLocal() { return local; }
-    public void setLocal(String local) { this.local = local; }
+    public String getLocal() {
+        return local;
+    }
 
-    public String getDescricao() { return descricao; }
-    public void setDescricao(String descricao) { this.descricao = descricao; }
+    public void setLocal(String local) {
+        this.local = local;
+    }
 
-    public double getAvaliacaoMedia() { return avaliacaoMedia; }
-    public int getQuantidadeAvaliacoes() { return quantidadeAvaliacoes; }
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public double getAvaliacaoMedia() {
+        return avaliacaoMedia;
+    }
+
+    public int getQuantidadeAvaliacoes() {
+        return quantidadeAvaliacoes;
+    }
 
     public void adicionarAvaliacao(int nota) {
         double total = this.avaliacaoMedia * this.quantidadeAvaliacoes;

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Reserva.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Reserva.java
@@ -1,42 +1,45 @@
 package br.com.senai.agenciaviagem.agenciaviagemapi.model;
 
+import jakarta.persistence.*;
 import java.time.LocalDate;
 
+@Entity
+@Table(name = "reserva")
 public class Reserva {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long idDestino;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destino_id")
+    private Destino destino;
+
     private String nomeCliente;
     private int quantidadePessoas;
     private LocalDate dataViagem;
 
-    public Reserva() {
-    }
-
-    public Reserva(Long id, Long idDestino, String nomeCliente, int quantidadePessoas, LocalDate dataViagem) {
-        this.id = id;
-        this.idDestino = idDestino;
-        this.nomeCliente = nomeCliente;
-        this.quantidadePessoas = quantidadePessoas;
-        this.dataViagem = dataViagem;
-    }
+    public Reserva() {}
 
     public Long getId() {
         return id;
     }
+
     public void setId(Long id) {
         this.id = id;
     }
 
-    public Long getIdDestino() {
-        return idDestino;
+    public Destino getDestino() {
+        return destino;
     }
-    public void setIdDestino(Long idDestino) {
-        this.idDestino = idDestino;
+
+    public void setDestino(Destino destino) {
+        this.destino = destino;
     }
 
     public String getNomeCliente() {
         return nomeCliente;
     }
+
     public void setNomeCliente(String nomeCliente) {
         this.nomeCliente = nomeCliente;
     }
@@ -44,6 +47,7 @@ public class Reserva {
     public int getQuantidadePessoas() {
         return quantidadePessoas;
     }
+
     public void setQuantidadePessoas(int quantidadePessoas) {
         this.quantidadePessoas = quantidadePessoas;
     }
@@ -51,6 +55,7 @@ public class Reserva {
     public LocalDate getDataViagem() {
         return dataViagem;
     }
+
     public void setDataViagem(LocalDate dataViagem) {
         this.dataViagem = dataViagem;
     }

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Usuario.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/model/Usuario.java
@@ -1,0 +1,49 @@
+package br.com.senai.agenciaviagem.agenciaviagemapi.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "usuario")
+public class Usuario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String password;
+    private String role;
+
+    public Usuario() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/DestinoRepository.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/DestinoRepository.java
@@ -1,0 +1,13 @@
+package br.com.senai.agenciaviagem.agenciaviagemapi.repository;
+
+import br.com.senai.agenciaviagem.agenciaviagemapi.model.Destino;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DestinoRepository extends JpaRepository<Destino, Long> {
+    @Query("SELECT d FROM Destino d WHERE (:nome IS NULL OR LOWER(d.nome) LIKE LOWER(CONCAT('%',:nome,'%'))) AND (:local IS NULL OR LOWER(d.local) LIKE LOWER(CONCAT('%',:local,'%')))")
+    List<Destino> buscar(@Param("nome") String nome, @Param("local") String local);
+}

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/ReservaRepository.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/ReservaRepository.java
@@ -1,0 +1,10 @@
+package br.com.senai.agenciaviagem.agenciaviagemapi.repository;
+
+import br.com.senai.agenciaviagem.agenciaviagemapi.model.Reserva;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservaRepository extends JpaRepository<Reserva, Long> {
+    List<Reserva> findByDestino_Id(Long destinoId);
+}

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/repository/UsuarioRepository.java
@@ -1,0 +1,10 @@
+package br.com.senai.agenciaviagem.agenciaviagemapi.repository;
+
+import br.com.senai.agenciaviagem.agenciaviagemapi.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Optional<Usuario> findByUsername(String username);
+}

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/security/SecurityConfig.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/security/SecurityConfig.java
@@ -1,0 +1,51 @@
+package br.com.senai.agenciaviagem.agenciaviagemapi.security;
+
+import br.com.senai.agenciaviagem.agenciaviagemapi.repository.UsuarioRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService(UsuarioRepository usuarioRepository) {
+        return username -> usuarioRepository.findByUsername(username)
+                .map(usuario -> org.springframework.security.core.userdetails.User
+                        .withUsername(usuario.getUsername())
+                        .password(usuario.getPassword())
+                        .roles(usuario.getRole().replace("ROLE_", ""))
+                        .build())
+                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider(UserDetailsService userDetailsService, PasswordEncoder encoder) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(encoder);
+        return provider;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/destinos/**").hasRole("ADMIN")
+                        .requestMatchers(org.springframework.http.HttpMethod.DELETE, "/destinos/**").hasRole("ADMIN")
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/destinos/**").hasAnyRole("USER", "ADMIN")
+                        .anyRequest().authenticated())
+                .httpBasic();
+        return http.build();
+    }
+}

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/service/DestinoService.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/service/DestinoService.java
@@ -1,49 +1,48 @@
 package br.com.senai.agenciaviagem.agenciaviagemapi.service;
 
 import br.com.senai.agenciaviagem.agenciaviagemapi.model.Destino;
+import br.com.senai.agenciaviagem.agenciaviagemapi.repository.DestinoRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class DestinoService {
-    private final Map<Long, Destino> destinos = new HashMap<>();
-    private final AtomicLong proximoId = new AtomicLong(1);
+    private final DestinoRepository destinoRepository;
+
+    public DestinoService(DestinoRepository destinoRepository) {
+        this.destinoRepository = destinoRepository;
+    }
 
     public List<Destino> listarTodos() {
-        return new ArrayList<>(destinos.values());
+        return destinoRepository.findAll();
     }
 
     public Destino salvar(Destino destino) {
-        Long id = proximoId.getAndIncrement();
-        destino.setId(id);
-        destinos.put(id, destino);
-        return destino;
+        return destinoRepository.save(destino);
     }
 
     public Optional<Destino> buscarPorId(Long id) {
-        return Optional.ofNullable(destinos.get(id));
+        return destinoRepository.findById(id);
     }
 
     public List<Destino> buscar(String nome, String local) {
-        return destinos.values().stream()
-                .filter(d ->
-                        (nome == null || d.getNome().toLowerCase().contains(nome.toLowerCase())) &&
-                                (local == null || d.getLocal().toLowerCase().contains(local.toLowerCase()))
-                )
-                .collect(Collectors.toList());
+        return destinoRepository.buscar(nome, local);
     }
 
     public void adicionarAvaliacao(Long id, int nota) {
-        Destino dest = destinos.get(id);
-        if (dest != null) {
-            dest.adicionarAvaliacao(nota);
-        }
+        destinoRepository.findById(id).ifPresent(d -> {
+            d.adicionarAvaliacao(nota);
+            destinoRepository.save(d);
+        });
     }
 
     public boolean excluir(Long id) {
-        return destinos.remove(id) != null;
+        if (destinoRepository.existsById(id)) {
+            destinoRepository.deleteById(id);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/service/ReservaService.java
+++ b/src/main/java/br/com/senai/agenciaviagem/agenciaviagemapi/service/ReservaService.java
@@ -1,32 +1,38 @@
 package br.com.senai.agenciaviagem.agenciaviagemapi.service;
 
+import br.com.senai.agenciaviagem.agenciaviagemapi.model.Destino;
 import br.com.senai.agenciaviagem.agenciaviagemapi.model.Reserva;
+import br.com.senai.agenciaviagem.agenciaviagemapi.repository.DestinoRepository;
+import br.com.senai.agenciaviagem.agenciaviagemapi.repository.ReservaRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 public class ReservaService {
-    private final Map<Long, Reserva> reservas = new HashMap<>();
-    private final AtomicLong proximoId = new AtomicLong(1);
+    private final ReservaRepository reservaRepository;
+    private final DestinoRepository destinoRepository;
+
+    public ReservaService(ReservaRepository reservaRepository, DestinoRepository destinoRepository) {
+        this.reservaRepository = reservaRepository;
+        this.destinoRepository = destinoRepository;
+    }
 
     public Reserva salvar(Long idDestino, Reserva reserva) {
-        Long id = proximoId.getAndIncrement();
-        reserva.setId(id);
-        reserva.setIdDestino(idDestino);
-        reservas.put(id, reserva);
-        return reserva;
+        Destino destino = destinoRepository.findById(idDestino).orElseThrow();
+        reserva.setDestino(destino);
+        return reservaRepository.save(reserva);
     }
 
     public List<Reserva> buscarPorDestinoId(Long idDestino) {
-        return reservas.values().stream()
-                .filter(r -> r.getIdDestino().equals(idDestino))
-                .collect(Collectors.toList());
+        return reservaRepository.findByDestino_Id(idDestino);
     }
 
     public boolean excluirPorId(Long idReserva) {
-        return reservas.remove(idReserva) != null;
+        if (reservaRepository.existsById(idReserva)) {
+            reservaRepository.deleteById(idReserva);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=agencia-viagem-api
+spring.datasource.url=jdbc:postgresql://localhost:5432/agenciaviagem
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.sql.init.mode=always

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO usuario (username, password, role) VALUES ('admin', '$2b$12$s9oIvznReKz9NG4r4DWn7Ov.BvTEwgVZ7.qe6vN6iGc0bBmwzjH3C', 'ROLE_ADMIN');

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=never


### PR DESCRIPTION
## Summary
- enable Spring Data JPA and Security dependencies
- configure PostgreSQL datasource
- create JPA entities for Destino, Reserva and Usuario
- implement repositories and update services for database access
- add basic security configuration with role-based access
- seed admin user via `data.sql`
- use in-memory database for tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685022d01660832a89a86b73ec411bf0